### PR TITLE
fix: add missing space in text loop

### DIFF
--- a/components/Home.js
+++ b/components/Home.js
@@ -56,7 +56,7 @@ function Home() {
               </div> */}
               Making Cloud Infrastructure for{" "}
               <span className="inline md:block">
-                the Life Sciences
+                the Life Sciences{" "}
                 {renderTextLoop()}
               </span>
             </div>


### PR DESCRIPTION
fixes #50 

previous:
![prev](https://user-images.githubusercontent.com/95133237/210091021-bd64c541-905d-48e6-9cfe-0820839eadfd.jpg)

after:
![after](https://user-images.githubusercontent.com/95133237/210091047-f12218f7-bf35-425e-8f64-51ea7831ee64.jpg)
