### PR TITLE
fix: light/dark mode bugs

### DIFF
--- a/components/Contributors/index.jsx
+++ b/components/Contributors/index.jsx
@@ -103,7 +103,7 @@ function Contributors({ contributors }) {
         {contributor.orcid ? (
           <a href={contributor.orcid}>
             <svg
-              fill={theme === 'light' ? '#000000' : '#ffffff'}
+              fill={theme.theme === 'light' ? '#000000' : '#ffffff'}
               height="24px"
               viewBox="0 0 32 32"
               width="24px"
@@ -118,7 +118,7 @@ function Contributors({ contributors }) {
         {contributor.researchgate ? (
           <a href={contributor.researchgate}>
             <svg
-              fill={theme === 'light' ? '#000000' : '#ffffff'}
+              fill={theme.theme === 'light' ? '#000000' : '#ffffff'}
               height="26px"
               viewBox="0 0 32 32"
               width="26px"
@@ -134,7 +134,7 @@ function Contributors({ contributors }) {
           <a href={contributor.scholar}>
             <svg
               className=""
-              fill={theme === 'light' ? '#000000' : '#ffffff'}
+              fill={theme.theme === 'light' ? '#000000' : '#ffffff'}
               height="24px"
               viewBox="0 0 24 24"
               width="24px"

--- a/components/News.jsx
+++ b/components/News.jsx
@@ -58,14 +58,14 @@ function News() {
 
   return (
     <Zoom>
-      <div className="mt-32 md:mx-96 mx-5">
+      <div className="mt-32 md:mx-96 mx-5 dark:bg-gray-900 rounded-xl">
         <TwitterTimelineEmbed
-          key={theme}
+          key={theme.theme}
           noFooter
           noHeader
           placeholder={renderLoading()}
           sourceType="profile"
-          theme={theme === 'light' ? 'light' : 'dark'}
+          theme={theme.theme === 'light' ? 'light' : 'dark'}
           transparent
           userId="1586382856267464708"
         />

--- a/components/News.jsx
+++ b/components/News.jsx
@@ -7,7 +7,7 @@ import themeContext from '../context/defaultTheme';
 function News() {
   const theme = useContext(themeContext);
   const renderLoading = () => (
-    <>
+    <div className="p-5">
       <ContentLoader
         backgroundColor="#f3f3f3"
         foregroundColor="#ecebeb"
@@ -53,7 +53,7 @@ function News() {
         <circle cx="20" cy="20" r="20" />
       </ContentLoader>
       <hr className="mb-5" />
-    </>
+    </div>
   );
 
   return (

--- a/components/Partners.jsx
+++ b/components/Partners.jsx
@@ -27,8 +27,8 @@ function Partners({ partners }) {
                 alt="Icon"
                 className="md:rounded-l-lg md:rounded-t-none rounded-t-lg md:w-32 md:h-32 p-5"
                 height="auto"
-                id={theme === 'dark' ? 'darkMode' : ''}
-                src={theme === 'light' ? partner.icon : partner.iconDark}
+                id={theme.theme === 'dark' ? 'darkMode' : ''}
+                src={theme.theme === 'light' ? partner.icon : partner.iconDark}
                 width="auto"
               />
               <div className="flex-grow p-5">


### PR DESCRIPTION
Resolves #92 

Contributors page bug fixed:
![Screenshot_20230123_002034](https://user-images.githubusercontent.com/76250685/216439703-1565f66c-feaf-4ebf-bc59-d87c2112e391.png)

News page light mode bug fixed:
![Screenshot (299)](https://user-images.githubusercontent.com/76250685/216440001-d8e43832-28d4-457c-ad61-6901f76e1f0c.png)

News page dark mode hover is still black:
![Screenshot (301)](https://user-images.githubusercontent.com/76250685/216439766-37181936-5bf0-4587-8591-a58407bc98c7.png)

I tried changing it with styled-components but it isn't working, I read at the [twitter forum](https://twittercommunity.com/t/suggestions-for-the-new-twitter-embed/175690/59) that they haven't fixed it.

@git-anurag-hub is there anything else that can be done??
@uniqueg